### PR TITLE
Updates ClinicalNLP deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -21,7 +21,7 @@
   year: 2023
   id: CLP23
   link: https://clinical-nlp.github.io/2023/
-  deadline: '2023-04-24 23:59:00'
+  deadline: '2023-05-02 23:59:00'
   timezone: UTC-12
   hybrid: false
   place: Toronto, Canada


### PR DESCRIPTION
Updates to match ClinicalNLP site (https://clinical-nlp.github.io/2023/).